### PR TITLE
Update start-orchestrator.mdx to add "gpu" in the binary file path

### DIFF
--- a/ai/orchestrators/start-orchestrator.mdx
+++ b/ai/orchestrators/start-orchestrator.mdx
@@ -112,13 +112,13 @@ Please follow the steps below to start your AI Subnet Orchestrator node:
                 Download the latest AI subnet binary for your system:
 
                 ```bash
-                wget https://build.livepeer.live/go-livepeer/ai-video/latest/livepeer-<OS>-<ARCH>.tar.gz
+                wget https://build.livepeer.live/go-livepeer/ai-video/latest/livepeer-<OS>-gpu-<ARCH>.tar.gz
                 ```
 
                 Replace `<OS>` and `<ARCH>` with your system's operating system and architecture. For example, for a Linux system with an AMD64 architecture, the command would be:
 
                 ```bash
-                wget https://build.livepeer.live/go-livepeer/ai-video/latest/livepeer-linux-amd64.tar.gz
+                wget https://build.livepeer.live/go-livepeer/ai-video/latest/livepeer-linux-gpu-amd64.tar.gz
                 ```
 
                 See the [go-livepeer installation guide](/orchestrators/guides/install-go-livepeer#install-using-a-binary-release) for more information on the available binaries.


### PR DESCRIPTION
Under the "Use Binaries" tab, at step 1, the example commands to download the latest AI subnet binary should contain "gpu" in the binary file path.